### PR TITLE
- bsc#1083455 - Internal error in yast configuration part

### DIFF
--- a/package/yast2-vm.changes
+++ b/package/yast2-vm.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 20 13:59:17 MDT 2018 - carnold@suse.com
+
+- bsc#1083455 - Internal error in yast configuration part
+  "Relocation Server Configuration" - "Service with name
+  'libvirtd-relocation-server' does not exist"
+- 3.2.6
+
+-------------------------------------------------------------------
 Fri Feb  9 12:19:42 MST 2018 - carnold@suse.com
 
 - The check for TextMode was in the wrong place and

--- a/package/yast2-vm.spec
+++ b/package/yast2-vm.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-vm
 #
-# Copyright (c) 2017 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2018 SUSE LINUX Products GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-vm
-Version:        3.2.5
+Version:        3.2.6
 Release:        0
 Group:		System/YaST
 

--- a/src/modules/RelocationServer.rb
+++ b/src/modules/RelocationServer.rb
@@ -245,14 +245,14 @@ module Yast
       @libvirtd_enabled = Service.Enabled("libvirtd")
       @sshd_enabled = Service.Enabled("sshd")
 
-      if Service.Status("libvirtd") == 0
+      if Service.active?("libvirtd") == 0
         @libvirtd_is_running = true
         Builtins.y2milestone("libvirtd is running")
       else
         @libvirtd_is_running = false
         Builtins.y2milestone("libvirtd is not running")
       end
-      if Service.Status("sshd") == 0
+      if Service.active?("sshd") == 0
         @sshd_is_running = true
         Builtins.y2milestone("sshd is running")
       else
@@ -261,7 +261,7 @@ module Yast
       end
 
       ports = SuSEFirewallServices.GetNeededTCPPorts(
-        "service:libvirtd-relocation-server"
+        "libvirtd-relocation-server"
       )
       @libvirtd_ports = Builtins.filter(ports) do |s|
         s != @libvirtd_default_ports
@@ -292,7 +292,7 @@ module Yast
           end
         end
         SuSEFirewallServices.SetNeededPortsAndProtocols(
-          "service:libvirtd-relocation-server",
+          "libvirtd-relocation-server",
           { "tcp_ports" => @libvirtd_ports }
         )
       end


### PR DESCRIPTION
  "Relocation Server Configuration" - "Service with name
  'libvirtd-relocation-server' does not exist"