### PR TITLE
Fixed build on i586

### DIFF
--- a/package/yast2-vm.changes
+++ b/package/yast2-vm.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 28 17:20:04 UTC 2018 - lslezak@suse.cz
+
+- Fixed build on i586 (related to the previous boo#1109310)
+- 4.1.0
+
+-------------------------------------------------------------------
 Mon Nov 26 05:51:44 UTC 2018 - Noah Davis <noahadvs@gmail.com>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-vm.spec
+++ b/package/yast2-vm.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-vm
-Version:        4.0.4
+Version:        4.1.0
 Release:        0
 Group:		System/YaST
 
@@ -53,6 +53,7 @@ This YaST module installs the tools necessary for creating VMs with Xen or KVM.
 %ifarch %ix86
 rm -f $RPM_BUILD_ROOT/usr/share/applications/YaST2/virtualization-config.desktop
 rm -f $RPM_BUILD_ROOT/usr/share/applications/YaST2/relocation-server.desktop
+rm -rf $RPM_BUILD_ROOT/usr/share/icons/*
 %endif
 
 


### PR DESCRIPTION
- On i586 we do not install the .desktop files so do not install the icons as well, otherwise rpm complains about installed but unpackaged files.
- Tested manually with `osc build openSUSE_Factory i586`