### PR TITLE
Fix bsc#1105891 virtualization test not supported for ppc64le

### DIFF
--- a/package/yast2-vm.changes
+++ b/package/yast2-vm.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 30 09:10:23 MDT 2019 - carnold@suse.com
+
+- bsc#1105891 - virtualization test not supported for ppc64le.
+  Allow yast-vm to run on ppc64le
+- 4.1.1
+
+-------------------------------------------------------------------
 Wed Nov 28 17:20:04 UTC 2018 - lslezak@suse.cz
 
 - Fixed build on i586 (related to the previous boo#1109310)

--- a/package/yast2-vm.spec
+++ b/package/yast2-vm.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-vm
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 Group:		System/YaST
 

--- a/src/clients/relocation-server.rb
+++ b/src/clients/relocation-server.rb
@@ -99,7 +99,7 @@ module Yast
       Builtins.y2milestone("Checking for Xen installation")
 
       # check the dom0 configuration...
-      ret = ret && VirtConfig.ConfigureDom0(Arch.s390_64)
+      ret = ret && VirtConfig.ConfigureDom0()
       return false if ret == false
 
       Builtins.y2milestone("CheckConfiguration returned: %1", ret)

--- a/src/clients/virtualization.rb
+++ b/src/clients/virtualization.rb
@@ -79,15 +79,14 @@ module Yast
       # check whether VM can be started (cannot start a vm using UML)
       return false if VirtConfig.isUML
 
-      # we only fully support x86_64
-      # s390 and aarch64 are technical preview
-      is_preview = Arch.s390_64 || Arch.aarch64
+      # s390, aarch64 and ppc64 are technical preview
+      is_preview = Arch.s390_64 || Arch.aarch64 || Arch.ppc64
       return false unless is_preview || VirtConfig.isX86_64
 
       Builtins.y2milestone("Checking for Virtualization installation")
 
       # check the dom0 configuration...
-      ret = ret && VirtConfig.ConfigureDom0(Arch.s390_64)
+      ret = ret && VirtConfig.ConfigureDom0()
       return false if ret == false
 
       Builtins.y2milestone("CheckConfiguration returned: %1", ret)

--- a/src/modules/VirtConfig.rb
+++ b/src/modules/VirtConfig.rb
@@ -206,7 +206,7 @@ module Yast
       false
     end
 
-    def ConfigureDom0(is_s390)
+    def ConfigureDom0()
       progress_stages = [
         # progress stage 1/2
         _("Verify Installed Packages"),
@@ -283,7 +283,7 @@ module Yast
       end
 
       # Generate a pop dialog to allow user selection of Xen or KVM
-      if is_s390 == true
+      if Arch.s390_64 || Arch.ppc64
         UI.OpenDialog(
                       HBox(
                         HSpacing(2),
@@ -435,7 +435,7 @@ module Yast
         end
       end
 
-      if is_s390 == false
+      if !Arch.s390_64
         # create a bridget for SLES host
         # Default Bridge stage
         Progress.NextStage


### PR DESCRIPTION
Add support in Factory in case someone wants to test this (which is what the bug is about). Currently yast2-vm is not found on the ppc64le SLE media (It is a PM decision whether to support it).