### PR TITLE
Fixed build on i586 arch

### DIFF
--- a/package/yast2-vm.changes
+++ b/package/yast2-vm.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun 12 10:27:01 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
+
+- Fixed build on i586 arch (related to fate#319035)
+- 4.2.2
+
+-------------------------------------------------------------------
 Tue Jun  4 10:59:39 MDT 2019 - carnold@suse.com
 
 - bsc#1105891 - virtualization test not supported for ppc64le.

--- a/package/yast2-vm.spec
+++ b/package/yast2-vm.spec
@@ -17,7 +17,7 @@
 
 Name:           yast2-vm
 Summary:        Configure Hypervisor and Tools for Xen and KVM
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -48,8 +48,8 @@ This YaST module installs the tools necessary for creating VMs with Xen or KVM.
 %yast_install
 
 %ifarch %ix86
-rm -f $RPM_BUILD_ROOT/usr/share/applications/YaST2/virtualization-config.desktop
-rm -f $RPM_BUILD_ROOT/usr/share/applications/YaST2/relocation-server.desktop
+rm -f $RPM_BUILD_ROOT/usr/share/applications/YaST2/org.opensuse.yast.VirtualizationConfig.desktop
+rm -f $RPM_BUILD_ROOT/usr/share/applications/YaST2/org.opensuse.yast.RelocationServer.desktop
 rm -rf $RPM_BUILD_ROOT/usr/share/icons/*
 %else
 %yast_metainfo


### PR DESCRIPTION
## Problem

```
[   63s] error: Installed (but unpackaged) file(s) found:
[   63s]    /usr/share/applications/YaST2/org.opensuse.yast.RelocationServer.desktop
[   63s]    /usr/share/applications/YaST2/org.opensuse.yast.VirtualizationConfig.desktop
```

It was caused by renaming the .desktop files in PR #42. It was not caught by Jenkins or Travis as both build on x86_64.

## Test

- Tested manually with `osc build openSUSE_Tumbleweed i586`
