### PR TITLE
Remove support for libvirt LXC containers and do not offer Xen virtualization options in aarch64

### DIFF
--- a/package/yast2-vm.changes
+++ b/package/yast2-vm.changes
@@ -2,7 +2,7 @@
 Tue Dec 15 15:31:59 UTC 2020 - Stefan Schubert <schubi@suse.de>
 
 - Removed old code for sysvinit configuration (bsc#1175494).
-- 4.2.5
+- 4.3.0
 
 -------------------------------------------------------------------
 Mon Aug 17 14:04:21 MDT 2020 - carnold@suse.com

--- a/package/yast2-vm.changes
+++ b/package/yast2-vm.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Dec 29 10:47:24 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- bsc#1180244, jsc#SLE-12781
+  * Drop support for "libvirt LXC containers"
+  * Do not offer Xen virtualization options in aarch64
+- Fix wrong number version 4.2.5 -> 4.3.0
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue Dec 15 15:31:59 UTC 2020 - Stefan Schubert <schubi@suse.de>
 
 - Removed old code for sysvinit configuration (bsc#1175494).

--- a/package/yast2-vm.spec
+++ b/package/yast2-vm.spec
@@ -17,7 +17,7 @@
 
 Name:           yast2-vm
 Summary:        Configure Hypervisor and Tools for Xen and KVM
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/package/yast2-vm.spec
+++ b/package/yast2-vm.spec
@@ -17,7 +17,7 @@
 
 Name:           yast2-vm
 Summary:        Configure Hypervisor and Tools for Xen and KVM
-Version:        4.2.5
+Version:        4.3.0
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/VirtConfig.rb
+++ b/src/modules/VirtConfig.rb
@@ -528,7 +528,7 @@ module Yast
     end
 
     def xen_widget
-      return if Arch.s390_64 || Arch.ppc64
+      return if Arch.s390_64 || Arch.ppc64 || Arch.aarch64
 
       Frame(
         _("Xen Hypervisor"),

--- a/src/modules/VirtConfig.rb
+++ b/src/modules/VirtConfig.rb
@@ -248,66 +248,14 @@ module Yast
       # error popup
       abortmsg = _("The installation will be aborted.")
 
-      def Information
-        widgets = Frame(_("Choose Hypervisor(s) to install"),
-                    HBox(
-                      VBox(
-                        Left(Label(_("Server: Minimal system to get a running Hypervisor"))),
-                        Left(Label(_("Tools: Configure, manage and monitor virtual machines"))),
-                        Left(Label(_("A disabled checkbox means the Hypervisor item has already been installed"))),
-                      ),
-                      HSpacing(2),
-                    ),
-                  )
-      end
-      def VMButtonBox
-        widgetB = ButtonBox(
-                    PushButton(Id(:accept), Label.AcceptButton),
-                    PushButton(Id(:cancel), Label.CancelButton),
-                  )
-      end
-      def KVMDialog
-        widgetKVM = Frame(_("KVM Hypervisor"),
-                      HBox(
-                        Left(CheckBox(Id(:kvm_server), Opt(:key_F6), _("KVM server"))),
-                        Left(CheckBox(Id(:kvm_tools), Opt(:key_F7), _("KVM tools"))),
-                      ),
-                    )
-      end
-
       # Generate a pop dialog to allow user selection of Xen or KVM
-      if Arch.s390_64 || Arch.ppc64
-        UI.OpenDialog(
-                      HBox(
-                        HSpacing(2),
-                        VBox(
-                          Information(),
-                          VSpacing(1),
-                          KVMDialog(),
-                          VMButtonBox(),
-                        ),
-                      ),
+      UI.OpenDialog(
+        MarginBox(2, 0,
+          VBox(
+            * widgets.flat_map { |w| [VSpacing(1), w] }
+          )
         )
-      else
-        UI.OpenDialog(
-                      HBox(
-                        HSpacing(2),
-                        VBox(
-                          VSpacing(1),
-                          Information(),
-                          VSpacing(1),
-                          Frame(_("Xen Hypervisor"),
-                            HBox(
-                              Left(CheckBox(Id(:xen_server), Opt(:key_F8), _("Xen server"))),
-                              Left(CheckBox(Id(:xen_tools), Opt(:key_F9), _("Xen tools"))),
-                            ),
-                          ),
-                          KVMDialog(),
-                          VMButtonBox(),
-                        ),
-                      ),
-        )
-      end
+      )
 
       log.info "VirtConfig::ConfigureDom0: Checking for Installed Patterns and Packages"
       UI.ChangeWidget(Id(:xen_server), :Enabled, !Package.Installed("patterns-server-xen_server"))
@@ -547,6 +495,52 @@ module Yast
 
       Builtins.y2milestone("VirtConfig::ConfigureDom0 returned: %1", success)
       success
+    end
+
+    def information_widget
+      Frame(
+        _("Choose Hypervisor(s) to install"),
+        MarginBox(1, 0.5,
+          VBox(
+            Left(Label(_("Server: Minimal system to get a running Hypervisor"))),
+            Left(Label(_("Tools: Configure, manage and monitor virtual machines"))),
+            Left(Label(_("A disabled checkbox means the Hypervisor item has already been installed")))
+          )
+        )
+      )
+    end
+
+    def button_box_widget
+      ButtonBox(
+        PushButton(Id(:accept), Label.AcceptButton),
+        PushButton(Id(:cancel), Label.CancelButton)
+      )
+    end
+
+    def kvm_widget
+      Frame(
+        _("KVM Hypervisor"),
+        HBox(
+          Left(CheckBox(Id(:kvm_server), Opt(:key_F6), _("KVM server"))),
+          Left(CheckBox(Id(:kvm_tools), Opt(:key_F7), _("KVM tools"))),
+        )
+      )
+    end
+
+    def xen_widget
+      return if Arch.s390_64 || Arch.ppc64
+
+      Frame(
+        _("Xen Hypervisor"),
+        HBox(
+          Left(CheckBox(Id(:xen_server), Opt(:key_F8), _("Xen server"))),
+          Left(CheckBox(Id(:xen_tools), Opt(:key_F9), _("Xen tools"))),
+        )
+      )
+    end
+
+    def widgets
+      [information_widget, xen_widget, kvm_widget, button_box_widget].compact
     end
 
     publish :function => :isOpenSuse, :type => "boolean ()"

--- a/src/modules/VirtConfig.rb
+++ b/src/modules/VirtConfig.rb
@@ -274,13 +274,6 @@ module Yast
                       ),
                     )
       end
-      def LXCDialog
-        widgetLXC = Frame(_("libvirt LXC containers"),
-                      HBox(
-                        Left(CheckBox(Id(:lxc), Opt(:key_F4), _("libvirt LXC daemon"))),
-                      ),
-                    )
-      end
 
       # Generate a pop dialog to allow user selection of Xen or KVM
       if Arch.s390_64 || Arch.ppc64
@@ -291,7 +284,6 @@ module Yast
                           Information(),
                           VSpacing(1),
                           KVMDialog(),
-                          LXCDialog(),
                           VMButtonBox(),
                         ),
                       ),
@@ -311,7 +303,6 @@ module Yast
                             ),
                           ),
                           KVMDialog(),
-                          LXCDialog(),
                           VMButtonBox(),
                         ),
                       ),
@@ -324,10 +315,6 @@ module Yast
       UI.ChangeWidget(Id(:kvm_server), :Enabled, !Package.Installed("patterns-server-kvm_server"))
       UI.ChangeWidget(Id(:kvm_tools), :Enabled, !Package.Installed("patterns-server-kvm_tools"))
 
-      if Package.Installed("libvirt-daemon-lxc") && Package.Installed("libvirt-daemon-config-network")
-        UI.ChangeWidget(Id(:lxc), :Enabled, false)
-      end
-
       widget_id = UI.UserInput
       if widget_id == :accept
           install_xen_server = UI.QueryWidget(Id(:xen_server), :Value)
@@ -335,7 +322,6 @@ module Yast
           install_kvm_server = UI.QueryWidget(Id(:kvm_server), :Value)
           install_kvm_tools = UI.QueryWidget(Id(:kvm_tools), :Value)
           install_client_tools = UI.QueryWidget(Id(:client_tools), :Value)
-          install_lxc = UI.QueryWidget(Id(:lxc), :Value)
       end
 
       UI.CloseDialog
@@ -349,7 +335,7 @@ module Yast
       install_kvm = true if install_kvm_server || install_kvm_tools
       install_vm = true if install_client_tools
 
-      if widget_id == :cancel || !install_vm && !install_lxc
+      if widget_id == :cancel || !install_vm
         Builtins.y2milestone(
           "VirtConfig::ConfigureDom0 Cancel Selected or no platform selected."
         )
@@ -379,14 +365,6 @@ module Yast
       common_vm_packages = []
 
       result = true
-      if install_lxc
-        packages = ["libvirt-daemon-lxc", "libvirt-daemon-config-network"]
-        result = Package.DoInstall(packages)
-        unless result
-          Report.Error(Message.FailedToInstallPackages)
-          return false
-        end
-      end
 
       packages << "patterns-server-xen_server" if install_xen_server
       packages << "patterns-server-xen_tools" if install_xen_tools
@@ -537,7 +515,6 @@ module Yast
       )
       message_xen_ready = _("Xen Hypervisor and tools are installed.")
       message_client_ready = _("Virtualization client tools are installed.")
-      message_lxc_ready = _("Libvirt LXC components are installed.")
       message = ""
 
       if Arch.is_xen == false
@@ -563,9 +540,7 @@ module Yast
         message.concat(message_client_ready)
         message.concat("\n\n")
       end
-      if install_lxc
-        message.concat(message_lxc_ready)
-      end
+
       Popup.LongMessage(message)
 
       Wizard.CloseDialog


### PR DESCRIPTION
## Problem

* All LXC related had already been removed from virtualization documentation ([jira#SLE-12781](https://jira.suse.com/browse/SLE-12781), [bsc#1180244](https://bugzilla.suse.com/show_bug.cgi?id=1180244)) but `yast2-vm` still offering _libvirt LXC containers_
* Xen virtualization options must not be offered in `aarch64` ([bsc#1180244](https://bugzilla.suse.com/show_bug.cgi?id=1180244))

## Solution

* Drop support for LXC containers
* Stop offering Xen virtualization sever and tools in `aarch64`

## Additional changes

The layout has been simplified and improved to fix a miss-alignment that was visible in some desktop environments.

## Tests

* Tested manually in `x86_64`
* Tested manually _simulating_ that is running in an `aarch64` system (by monkey patching [`Yast::Arch.aarch64`](https://github.com/yast/yast-yast2/blob/2b4b1e78d1509e4b99164345a9d668c8208a8799/library/general/src/modules/Arch.rb#L167-L170) :see_no_evil: )

## Notes

I was tempted to also simplified some other parts of the code, but finally I decided to keep it as it is because:

* There are no unit tests
* Not sure if actually worth it
* I realized that actually this module is maintained by @charlesa 

## Screenshot

<details>
<summary>Click to show/hide some screenshots</summary>

---


  | | Before | After |
  |-|-|-|
  | ncurses | ![ncurses_80x24_before](https://user-images.githubusercontent.com/1691872/103285181-4df9a480-49d5-11eb-96e7-2cedca53b12c.png) | ![ncurses_80x24_after](https://user-images.githubusercontent.com/1691872/103285188-54881c00-49d5-11eb-84da-ff294fcdeabd.png) |
  | IceWM | ![icewm_before](https://user-images.githubusercontent.com/1691872/103281009-acb92100-49c9-11eb-9384-1f8bb7f86299.png) | ![icewm_after](https://user-images.githubusercontent.com/1691872/103281021-b6428900-49c9-11eb-8635-98566ce69cfb.png) |
  | KDE |  ![kde_before](https://user-images.githubusercontent.com/1691872/103281102-e853eb00-49c9-11eb-914c-da699061cd40.png) | ![kde_after](https://user-images.githubusercontent.com/1691872/103281115-ef7af900-49c9-11eb-8e9f-9325f48624eb.png) |
  | Gnome | ![gnome_before](https://user-images.githubusercontent.com/1691872/103281044-c195b480-49c9-11eb-9ae1-d3a71a345565.png) | ![gnome_after](https://user-images.githubusercontent.com/1691872/103281056-c8bcc280-49c9-11eb-8342-3fb7984eb07a.png) |

</details>


---

<sub> YaST Trello card: https://trello.com/c/MWzg8JoO </sub>


