### PR TITLE
The libvirtd daemon is deprecated and is going away.

### DIFF
--- a/package/yast2-vm.changes
+++ b/package/yast2-vm.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Apr 20 15:22:54 MDT 2023 - carnold@suse.com
+
+- The libvirtd daemon is deprecated and is going away.
+  The replacements are virtqemud for KVM/qemu and virtxend for Xen.
+  (bsc#1210572)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-vm.spec
+++ b/package/yast2-vm.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-vm
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-vm
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        Configure Hypervisor and Tools for Xen and KVM
 License:        GPL-2.0-only

--- a/src/modules/VirtConfig.rb
+++ b/src/modules/VirtConfig.rb
@@ -434,13 +434,28 @@ module Yast
       # Force AppArmor to reload the profiles
       reloadApparmor
 
-      # Enable and start the libvirtd daemon for both KVM and Xen
-      cmd = "systemctl enable libvirtd.service"
-      Builtins.y2milestone("Enable libvirtd.service: %1", cmd)
-      SCR.Execute(path(".target.bash"), cmd)
-      cmd = "systemctl start libvirtd.service"
-      Builtins.y2milestone("Start libvirtd.service: %1", cmd)
-      SCR.Execute(path(".target.bash"), cmd)
+      # Enable and start the libvirt virtqemud daemon for KVM
+      if install_kvm
+        cmd = "systemctl enable virtqemud.service"
+        Builtins.y2milestone("Enable virtqemud.service: %1", cmd)
+        SCR.Execute(path(".target.bash"), cmd)
+        if Arch.is_xen == false
+          cmd = "systemctl start virtqemud.service"
+          Builtins.y2milestone("Start virtqemud.service: %1", cmd)
+          SCR.Execute(path(".target.bash"), cmd)
+        end
+      end
+      # Enable and start the libvirt virtxend daemon for Xen
+      if install_xen
+        cmd = "systemctl enable virtxend.service"
+        Builtins.y2milestone("Enable virtxend.service: %1", cmd)
+        SCR.Execute(path(".target.bash"), cmd)
+        if Arch.is_xen == true
+          cmd = "systemctl start virtxend.service"
+          Builtins.y2milestone("Start virtxend.service: %1", cmd)
+          SCR.Execute(path(".target.bash"), cmd)
+        end
+      end
 
       # Enable and start the virtlogd socket (libvirt >= 1.3.0) for both KVM and Xen
       cmd = "systemctl enable virtlogd.socket"


### PR DESCRIPTION
  The replacements are virtqemud for KVM/qemu and virtxend for Xen.
  (bsc#1210572)
- 4.6.1


## Problem

The libvirtd daemon is deprecated and is going away.
yast-vm tries to enable and start libvirtd which will fail.


- https://bugzilla.suse.com/show_bug.cgi?id=1210572
- *openQA link*
- *Links to other related pull requests*


## Solution

The replacement daemons for libvirtd are virtqemud for KVM/qemu and virtxend for Xen. The code will now enable and start the appropriate daemon depending on the user selection in the GUI and how the host has been booted (Xen or native).


## Testing

- *Tested manually*
A simple way to test this on Tumbleweed
1. rpm -e patterns-server-kvm_tools patterns-server-xen_tools
2. yast2 virtualization
3. Check either (or both) KVM Tools or Xen Tools and click Accept.
The appropriate daemon will be enabled based on user selection. The appropriate daemon will also be started depending on whether the host is booted into Xen or booted native for KVM.


## Screenshots

No change to GUI interface

